### PR TITLE
Add target to file element in nuspec

### DIFF
--- a/nuget/Apptentive.iOS.nuspec
+++ b/nuget/Apptentive.iOS.nuspec
@@ -14,6 +14,6 @@
     <iconUrl>https://raw.githubusercontent.com/apptentive/apptentive-xamarin-ios/master/icons/apptentive_128x128.png</iconUrl>
   </metadata>
   <files>
-    <file src="../source/bin/Release/Apptentive.iOS.dll" target="lib/Apptentive.iOS.dll" />
+    <file src="../source/bin/Release/Apptentive.iOS.dll" target="lib/Xamarin.iOS10" />
   </files>
 </package>


### PR DESCRIPTION
This is apparently the second piece that is needed to make Xamarin forms work. This got lost in the first round of changes, unfortunately, so we need to release a 5.2.5. 